### PR TITLE
use correct framework

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/SteganographyApp/bin/Debug/netcoreapp2.1/SteganographyApp.dll",
+            "program": "${workspaceFolder}/SteganographyApp/bin/Debug/net8.0/SteganographyApp.dll",
             "args": [],
             "cwd": "${workspaceFolder}/SteganographyApp",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/SteganographyApp.Common.Arguments.Tests/SteganographyApp.Common.Arguments.Tests.csproj
+++ b/SteganographyApp.Common.Arguments.Tests/SteganographyApp.Common.Arguments.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/SteganographyApp.Common.Arguments/SteganographyApp.Common.Arguments.csproj
+++ b/SteganographyApp.Common.Arguments/SteganographyApp.Common.Arguments.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <CodeAnalysisRuleSet>StyleCop.Analyzers.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/SteganographyApp.Common.Benchmarks/SteganographyApp.Common.Benchmarks.csproj
+++ b/SteganographyApp.Common.Benchmarks/SteganographyApp.Common.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SteganographyApp.Common.Integration.Tests/SteganographyApp.Common.Integration.Tests.csproj
+++ b/SteganographyApp.Common.Integration.Tests/SteganographyApp.Common.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <CodeAnalysisRuleSet>StyleCop.Analyzers.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/SteganographyApp.Common.Tests/SteganographyApp.Common.Tests.csproj
+++ b/SteganographyApp.Common.Tests/SteganographyApp.Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <CodeAnalysisRuleSet>StyleCop.Analyzers.ruleset</CodeAnalysisRuleSet>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/SteganographyApp.Common/SteganographyApp.Common.csproj
+++ b/SteganographyApp.Common/SteganographyApp.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <CodeAnalysisRuleSet>StyleCop.Analyzers.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/SteganographyApp/SteganographyApp.csproj
+++ b/SteganographyApp/SteganographyApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <CodeAnalysisRuleSet>StyleCop.Analyzers.ruleset</CodeAnalysisRuleSet>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/create_testbed.ps1
+++ b/create_testbed.ps1
@@ -28,7 +28,7 @@ New-Item -Path ./testbed -ItemType Directory | Out-Null
 
 Write-Host "`n---------- Copying publish output ----------`n"
 Write-Host "Copying output from SteganographyApp publish"
-Get-ChildItem -Path ./SteganographyApp/bin/release/netcoreapp8.0/publish | Copy-Item -Recurse -Destination ./testbed
+Get-ChildItem -Path ./SteganographyApp/bin/release/net8.0/publish | Copy-Item -Recurse -Destination ./testbed
 
 
 Write-Host "`n---------- Copying test assets ----------`n"

--- a/run_publish.ps1
+++ b/run_publish.ps1
@@ -43,8 +43,8 @@ function Copy-Folder {
     )
 
     Write-Host "Copying output from $Project publish"
-    Copy-Item ./$Project/bin/$Folder/netcoreapp8.0/publish -Recurse -Destination $Output
-    Get-ChildItem -Path ./$Project/bin/$Folder/netcoreapp8.0/ | Where-Object Name -Like "*.dll" | Copy-Item -Force -Destination ./publish
+    Copy-Item ./$Project/bin/$Folder/net8.0/publish -Recurse -Destination $Output
+    Get-ChildItem -Path ./$Project/bin/$Folder/net8.0/ | Where-Object Name -Like "*.dll" | Copy-Item -Force -Destination ./publish
 
     if (-Not($Rename -eq "")) {
         cd publish

--- a/run_tests.ps1
+++ b/run_tests.ps1
@@ -56,7 +56,7 @@ Write-Host "`n---------- Running unit tests ----------`n"
 
 Write-Host "---------- Running SteganographyApp.Common.Tests tests ----------"
 dotnet tool run coverlet `
-    ./SteganographyApp.Common.Tests/bin/Debug/netcoreapp8.0/SteganographyApp.Common.Tests.dll `
+    ./SteganographyApp.Common.Tests/bin/Debug/net8.0/SteganographyApp.Common.Tests.dll `
     --target "dotnet" `
     --targetargs "test ./SteganographyApp.Common.Tests --no-build" `
     --exclude-by-file "**/RootLogger.cs" `
@@ -74,7 +74,7 @@ if($LastExitCode -ne 0) {
 
 Write-Host "---------- Running SteganographyApp.Common.Arguments.Tests tests ----------"
 dotnet tool run coverlet `
-    ./SteganographyApp.Common.Arguments.Tests/bin/Debug/netcoreapp8.0/SteganographyApp.Common.Arguments.Tests.dll `
+    ./SteganographyApp.Common.Arguments.Tests/bin/Debug/net8.0/SteganographyApp.Common.Arguments.Tests.dll `
     --target "dotnet" `
     --targetargs "test ./SteganographyApp.Common.Arguments.Tests --no-build" `
     --exclude-by-file "**/Help.cs" `


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)